### PR TITLE
Add Blocks ↔ Markdown toggle and inline raw Markdown editor

### DIFF
--- a/PRIVACY-POLICY.md
+++ b/PRIVACY-POLICY.md
@@ -3,38 +3,50 @@
 Last updated: October 29, 2025
 
 ## Overview
+
 DecaNotes is a decentralized note-taking application that prioritizes your privacy and data ownership.
 
 ## Data Collection
+
 DecaNotes does NOT collect, store, or transmit any personal data to our servers. We do not have servers.
 
 ## Data Storage
+
 - **Local Storage**: Notes are stored only on your device
 - **Sia Renterd**: If you choose this option, notes are encrypted and stored on the Sia decentralized network using your own credentials
 - **IPFS**: If you choose this option, notes are stored on the IPFS network using your configuration
 
 ## Data Security
+
 All data stored through DecaNotes is under your complete control:
+
 - Local storage uses your device's secure storage
 - Decentralized storage options (Sia, IPFS) use your own encryption keys and credentials
 - We never have access to your notes or credentials
 
 ## Third-Party Services
+
 When you use decentralized storage options (Sia or IPFS), you connect directly to those networks. Please review their respective privacy policies:
+
 - Sia Network: https://sia.tech
 - IPFS: https://ipfs.tech
 
 ## Analytics and Tracking
+
 We do not use any analytics, tracking, or telemetry services. Your usage of DecaNotes is completely private.
 
 ## Children's Privacy
+
 DecaNotes does not knowingly collect any information from children under 13 years of age.
 
 ## Changes to This Policy
+
 We may update this Privacy Policy from time to time. We will notify users of any changes by updating the "Last updated" date.
 
 ## Contact
+
 For questions about privacy, please open an issue at: https://github.com/StringNick/decanotes/issues
 
 ## Your Rights
+
 Since we do not collect any data, there is no data to access, modify, or delete. You have complete control over all your notes stored locally or on decentralized networks.

--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -7,15 +7,15 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
 import {
-    Alert,
-    KeyboardAvoidingView,
-    Platform,
-    ScrollView,
-    StyleSheet,
-    Text,
-    TextInput,
-    TouchableOpacity,
-    View,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
 } from 'react-native';
 
 type AuthMethod = StorageBackendType;
@@ -152,13 +152,7 @@ export default function AuthScreen() {
                 </Text>
               </TouchableOpacity>
 
-              <View
-                style={[
-                  styles.methodButton,
-                  styles.disabledMethodButton,
-                  { opacity: 0.5 },
-                ]}
-              >
+              <View style={[styles.methodButton, styles.disabledMethodButton, { opacity: 0.5 }]}>
                 <View style={styles.methodButtonContent}>
                   <IconSymbol name="globe" size={18} color="#6B7280" />
                   <Text style={styles.methodText}>IPFS</Text>

--- a/app/editor.tsx
+++ b/app/editor.tsx
@@ -7,37 +7,37 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Crypto from 'expo-crypto';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import {
-    CheckSquare,
-    Code,
-    Heading1,
-    Heading2,
-    Heading3,
-    Lightbulb,
-    List,
-    ListOrdered,
-    Minus,
-    Plus,
-    Quote,
-    Redo2,
-    Save,
-    Table,
-    Type,
-    Undo2,
-    X,
+  CheckSquare,
+  Code,
+  Heading1,
+  Heading2,
+  Heading3,
+  Lightbulb,
+  List,
+  ListOrdered,
+  Minus,
+  Plus,
+  Quote,
+  Redo2,
+  Save,
+  Table,
+  Type,
+  Undo2,
+  X,
 } from 'lucide-react-native';
 import React, { StrictMode, useCallback, useEffect, useRef, useState } from 'react';
 import {
-    ActivityIndicator,
-    Alert,
-    Keyboard,
-    Modal,
-    ScrollView,
-    StatusBar,
-    StyleSheet,
-    Text,
-    TextInput,
-    TouchableOpacity,
-    View,
+  ActivityIndicator,
+  Alert,
+  Keyboard,
+  Modal,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MarkdownEditor } from '../components/editor/MarkdownEditor';
@@ -270,8 +270,16 @@ export default function EditorScreen() {
   const params = useLocalSearchParams<{ noteId?: string }>();
   const { effectiveTheme } = useTheme();
   const colorScheme = effectiveTheme; // Use app theme setting instead of system theme
-  const { loadNote, saveNote, currentNote, setCurrentNote, hasUnsavedChanges, markAsChanged, clearUnsavedChanges, autoSaveEnabled } =
-    useStorage();
+  const {
+    loadNote,
+    saveNote,
+    currentNote,
+    setCurrentNote,
+    hasUnsavedChanges,
+    markAsChanged,
+    clearUnsavedChanges,
+    autoSaveEnabled,
+  } = useStorage();
 
   const editorRef = useRef<ExtendedMarkdownEditorRef>(null);
   const [blocks, setBlocks] = useState<EditorBlock[]>([]);
@@ -469,7 +477,7 @@ export default function EditorScreen() {
       initialBlocksRef.current = blocks;
       clearUnsavedChanges();
       setSaveStatus('saved');
-      
+
       // Show saved status briefly, then hide
       setTimeout(() => setSaveStatus('saved'), 1000);
     } catch (error) {
@@ -529,50 +537,53 @@ export default function EditorScreen() {
   }, []);
 
   // Handle formatting actions
-  const handleFormattingAction = useCallback((actionId: string) => {
-    if (!editorRef.current) return;
+  const handleFormattingAction = useCallback(
+    (actionId: string) => {
+      if (!editorRef.current) return;
 
-    // Get current blocks
-    const currentBlocks = editorRef.current.getBlocks();
-    if (currentBlocks.length === 0) return;
+      // Get current blocks
+      const currentBlocks = editorRef.current.getBlocks();
+      if (currentBlocks.length === 0) return;
 
-    // For now, apply formatting to the last block (where cursor likely is)
-    const lastBlock = currentBlocks[currentBlocks.length - 1];
-    if (!lastBlock || lastBlock.type !== 'paragraph') return;
+      // For now, apply formatting to the last block (where cursor likely is)
+      const lastBlock = currentBlocks[currentBlocks.length - 1];
+      if (!lastBlock || lastBlock.type !== 'paragraph') return;
 
-    const content = lastBlock.content;
-    let newContent = content;
+      const content = lastBlock.content;
+      let newContent = content;
 
-    switch (actionId) {
-      case 'bold':
-        newContent = content.includes('**') ? content.replace(/\*\*/g, '') : `**${content}**`;
-        break;
-      case 'italic':
-        newContent = content.includes('*') && !content.includes('**') ? content.replace(/\*/g, '') : `*${content}*`;
-        break;
-      case 'strikethrough':
-        newContent = content.includes('~~') ? content.replace(/~~/g, '') : `~~${content}~~`;
-        break;
-      case 'code':
-        newContent = content.includes('`') ? content.replace(/`/g, '') : `\`${content}\``;
-        break;
-      case 'link':
-        if (!content.includes('[')) {
-          newContent = `[${content}](url)`;
-        }
-        break;
-      default:
-        return;
-    }
+      switch (actionId) {
+        case 'bold':
+          newContent = content.includes('**') ? content.replace(/\*\*/g, '') : `**${content}**`;
+          break;
+        case 'italic':
+          newContent = content.includes('*') && !content.includes('**') ? content.replace(/\*/g, '') : `*${content}*`;
+          break;
+        case 'strikethrough':
+          newContent = content.includes('~~') ? content.replace(/~~/g, '') : `~~${content}~~`;
+          break;
+        case 'code':
+          newContent = content.includes('`') ? content.replace(/`/g, '') : `\`${content}\``;
+          break;
+        case 'link':
+          if (!content.includes('[')) {
+            newContent = `[${content}](url)`;
+          }
+          break;
+        default:
+          return;
+      }
 
-    // Update blocks array
-    const updatedBlocks = [...currentBlocks];
-    updatedBlocks[updatedBlocks.length - 1] = { ...lastBlock, content: newContent };
-    
-    // Apply via setBlocks
-    setBlocks(updatedBlocks);
-    markAsChanged();
-  }, [markAsChanged]);
+      // Update blocks array
+      const updatedBlocks = [...currentBlocks];
+      updatedBlocks[updatedBlocks.length - 1] = { ...lastBlock, content: newContent };
+
+      // Apply via setBlocks
+      setBlocks(updatedBlocks);
+      markAsChanged();
+    },
+    [markAsChanged]
+  );
 
   // Handle rename
   const handleRename = useCallback(() => {
@@ -595,29 +606,29 @@ export default function EditorScreen() {
   // Toggle markdown mode
   const handleToggleMarkdownMode = useCallback(() => {
     console.log('[Toggle] Called, isMarkdownMode:', isMarkdownMode);
-    
+
     if (isMarkdownMode) {
       // Switching from markdown to blocks - parse and apply changes
       console.log('[Toggle] Switching to BLOCKS mode, markdown length:', markdownText.length);
-      
+
       try {
         // Import the parser directly to parse markdown into blocks
         // We can't use editorRef here because MarkdownEditor is unmounted
         const { parseMarkdownToBlocks } = require('../components/editor/utils/MarkdownRegistry');
-        
+
         // Parse markdown to blocks (using built-in plugins)
         const parsedBlocks = parseMarkdownToBlocks(markdownText, []);
         console.log('[Toggle] Parsed blocks:', parsedBlocks.length);
-        
+
         // Update blocks state - this will trigger the editor to re-render with new blocks
         setBlocks(parsedBlocks);
-        
+
         // Mark as changed if content differs
         const hasActualChanges = JSON.stringify(parsedBlocks) !== JSON.stringify(initialBlocksRef.current);
         if (hasActualChanges && !isInitialLoad.current) {
           markAsChanged();
         }
-        
+
         // Switch mode
         setIsMarkdownMode(false);
       } catch (error) {
@@ -627,7 +638,7 @@ export default function EditorScreen() {
     } else {
       // Switching from blocks to markdown - get fresh markdown
       console.log('[Toggle] Switching to MARKDOWN mode');
-      
+
       if (editorRef.current) {
         const markdown = editorRef.current.getMarkdown();
         console.log('[Toggle] Got markdown, length:', markdown.length);
@@ -638,12 +649,15 @@ export default function EditorScreen() {
   }, [isMarkdownMode, markdownText, markAsChanged]);
 
   // Handle markdown text change
-  const handleMarkdownTextChange = useCallback((text: string) => {
-    setMarkdownText(text);
-    if (!isInitialLoad.current) {
-      markAsChanged();
-    }
-  }, [markAsChanged]);
+  const handleMarkdownTextChange = useCallback(
+    (text: string) => {
+      setMarkdownText(text);
+      if (!isInitialLoad.current) {
+        markAsChanged();
+      }
+    },
+    [markAsChanged]
+  );
 
   // Block types for the menu - Notion-style
   const blockTypes: {
@@ -742,10 +756,15 @@ export default function EditorScreen() {
         barStyle={colorScheme === 'dark' ? 'light-content' : 'dark-content'}
         backgroundColor={colors.background}
       />
-      
+
       {/* Save Status Toast */}
       {saveStatus !== 'saved' && (
-        <View style={[styles.saveToast, { backgroundColor: colorScheme === 'dark' ? 'rgba(0,0,0,0.8)' : 'rgba(255,255,255,0.95)' }]}>
+        <View
+          style={[
+            styles.saveToast,
+            { backgroundColor: colorScheme === 'dark' ? 'rgba(0,0,0,0.8)' : 'rgba(255,255,255,0.95)' },
+          ]}
+        >
           <Text style={[styles.saveToastText, { color: colors.text }]}>
             {saveStatus === 'saving' ? '💾 Saving...' : saveStatus === 'unsaved' ? '✏️ Unsaved changes' : ''}
           </Text>
@@ -801,14 +820,11 @@ export default function EditorScreen() {
                 )}
               </TouchableOpacity>
             )}
-            
+
             {/* Тумблер Blocks ↔ Markdown */}
             <View style={styles.modeToggleContainer}>
               <TouchableOpacity
-                style={[
-                  styles.modeToggleButton,
-                  !isMarkdownMode && styles.modeToggleButtonActive,
-                ]}
+                style={[styles.modeToggleButton, !isMarkdownMode && styles.modeToggleButtonActive]}
                 onPress={() => {
                   if (isMarkdownMode) {
                     handleToggleMarkdownMode();
@@ -818,10 +834,7 @@ export default function EditorScreen() {
                 <Type size={14} color={!isMarkdownMode ? colors.background : colors.textSecondary} />
               </TouchableOpacity>
               <TouchableOpacity
-                style={[
-                  styles.modeToggleButton,
-                  isMarkdownMode && styles.modeToggleButtonActive,
-                ]}
+                style={[styles.modeToggleButton, isMarkdownMode && styles.modeToggleButtonActive]}
                 onPress={() => {
                   if (!isMarkdownMode) {
                     handleToggleMarkdownMode();
@@ -847,7 +860,7 @@ export default function EditorScreen() {
         </View>
       ) : isMarkdownMode ? (
         <View style={styles.editorContainer}>
-          <ScrollView 
+          <ScrollView
             style={styles.markdownScrollContainer}
             contentContainerStyle={{ paddingBottom: keyboardOffset || 20 }}
             keyboardShouldPersistTaps="handled"
@@ -940,7 +953,6 @@ export default function EditorScreen() {
           </View>
         </View>
       </Modal>
-
     </SafeAreaView>
   );
 }

--- a/app/editor.tsx
+++ b/app/editor.tsx
@@ -1,15 +1,14 @@
 import { Colors } from '@/constants/Colors';
 import { useStorage } from '@/contexts/StorageContext';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useKeyboardOffset } from '@/hooks/useKeyboardOffset';
 import type { Note } from '@/types/storage';
 import { Ionicons } from '@expo/vector-icons';
-import * as Clipboard from 'expo-clipboard';
 import * as Crypto from 'expo-crypto';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import {
     CheckSquare,
     Code,
-    Copy,
     Heading1,
     Heading2,
     Heading3,
@@ -43,8 +42,6 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MarkdownEditor } from '../components/editor/MarkdownEditor';
 import { FormattingToolbar } from '../components/editor/components/FormattingToolbar';
-// EditorBottomBar now rendered inside MarkdownEditor
-import { useKeyboardOffset } from '@/hooks/useKeyboardOffset';
 import { ExtendedMarkdownEditorRef } from '../components/editor/types/EditorTypes';
 import { getEditorTheme } from '../themes/defaultTheme';
 import { EditorBlock, EditorBlockType } from '../types/editor';
@@ -285,10 +282,8 @@ export default function EditorScreen() {
   const [noteTitle, setNoteTitle] = useState('Untitled');
   const [showRenameModal, setShowRenameModal] = useState(false);
   const [tempTitle, setTempTitle] = useState('');
-  const [showMarkdownModal, setShowMarkdownModal] = useState(false);
-  const [rawMarkdown, setRawMarkdown] = useState('');
-  const [isEditingMarkdown, setIsEditingMarkdown] = useState(false);
-  const [editedMarkdown, setEditedMarkdown] = useState('');
+  const [isMarkdownMode, setIsMarkdownMode] = useState(false);
+  const [markdownText, setMarkdownText] = useState('');
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved');
   const isInitialLoad = useRef(true);
   const initialBlocksRef = useRef<EditorBlock[]>([]);
@@ -597,85 +592,58 @@ export default function EditorScreen() {
     setShowRenameModal(false);
   }, [tempTitle, markAsChanged]);
 
-  // Get raw markdown
-  const handleGetRawMarkdown = useCallback(() => {
-    if (editorRef.current) {
-      const markdown = editorRef.current.getMarkdown();
-      setRawMarkdown(markdown);
-      setEditedMarkdown(markdown);
-      setIsEditingMarkdown(false);
-      setShowMarkdownModal(true);
-    }
-  }, []);
-
-  // Copy markdown to clipboard (unused but kept for future feature)
-  // const handleCopyMarkdown = useCallback(async () => {
-  //   if (editorRef.current) {
-  //     const markdown = editorRef.current.getMarkdown();
-  //     await Clipboard.setStringAsync(markdown);
-  //     Alert.alert('Copied!', 'Markdown copied to clipboard');
-  //   }
-  // }, []);
-
-  const handleCopyFromModal = useCallback(async () => {
-    await Clipboard.setStringAsync(isEditingMarkdown ? editedMarkdown : rawMarkdown);
-    Alert.alert('Copied!', 'Markdown copied to clipboard');
-  }, [rawMarkdown, editedMarkdown, isEditingMarkdown]);
-
-  // Apply edited markdown
-  const handleApplyMarkdown = useCallback(() => {
-    if (editorRef.current && editedMarkdown !== rawMarkdown) {
+  // Toggle markdown mode
+  const handleToggleMarkdownMode = useCallback(() => {
+    console.log('[Toggle] Called, isMarkdownMode:', isMarkdownMode);
+    
+    if (isMarkdownMode) {
+      // Switching from markdown to blocks - parse and apply changes
+      console.log('[Toggle] Switching to BLOCKS mode, markdown length:', markdownText.length);
+      
       try {
-        // Apply the markdown to the editor
-        editorRef.current.setMarkdown(editedMarkdown);
-
-        // Get the updated blocks from the editor after parsing
-        setTimeout(() => {
-          if (editorRef.current) {
-            const updatedBlocks = editorRef.current.getBlocks();
-
-            if (__DEV__) {
-              const footnoteBlocks = updatedBlocks.filter(b => b.type === 'footnote');
-              console.log('[handleApplyMarkdown] Updated blocks count:', updatedBlocks.length);
-              console.log(
-                '[handleApplyMarkdown] Footnote blocks:',
-                footnoteBlocks.length,
-                footnoteBlocks.map(b => b.meta?.footnoteId)
-              );
-              console.log(
-                '[handleApplyMarkdown] Block types:',
-                updatedBlocks.map(b => b.type)
-              );
-            }
-
-            setBlocks(updatedBlocks);
-          }
-        }, 100);
-
-        setRawMarkdown(editedMarkdown);
-        setIsEditingMarkdown(false);
-        markAsChanged();
-        Alert.alert('Success', 'Markdown applied successfully!');
+        // Import the parser directly to parse markdown into blocks
+        // We can't use editorRef here because MarkdownEditor is unmounted
+        const { parseMarkdownToBlocks } = require('../components/editor/utils/MarkdownRegistry');
+        
+        // Parse markdown to blocks (using built-in plugins)
+        const parsedBlocks = parseMarkdownToBlocks(markdownText, []);
+        console.log('[Toggle] Parsed blocks:', parsedBlocks.length);
+        
+        // Update blocks state - this will trigger the editor to re-render with new blocks
+        setBlocks(parsedBlocks);
+        
+        // Mark as changed if content differs
+        const hasActualChanges = JSON.stringify(parsedBlocks) !== JSON.stringify(initialBlocksRef.current);
+        if (hasActualChanges && !isInitialLoad.current) {
+          markAsChanged();
+        }
+        
+        // Switch mode
+        setIsMarkdownMode(false);
       } catch (error) {
-        console.error('Failed to apply markdown:', error);
+        console.error('[Toggle] Failed to parse markdown:', error);
         Alert.alert('Error', 'Failed to parse markdown. Please check your syntax.');
       }
     } else {
-      setIsEditingMarkdown(false);
+      // Switching from blocks to markdown - get fresh markdown
+      console.log('[Toggle] Switching to MARKDOWN mode');
+      
+      if (editorRef.current) {
+        const markdown = editorRef.current.getMarkdown();
+        console.log('[Toggle] Got markdown, length:', markdown.length);
+        setMarkdownText(markdown);
+      }
+      setIsMarkdownMode(true);
     }
-  }, [editedMarkdown, rawMarkdown, markAsChanged]);
+  }, [isMarkdownMode, markdownText, markAsChanged]);
 
-  // Start editing markdown
-  const handleEditMarkdown = useCallback(() => {
-    setEditedMarkdown(rawMarkdown);
-    setIsEditingMarkdown(true);
-  }, [rawMarkdown]);
-
-  // Cancel editing markdown
-  const handleCancelEditMarkdown = useCallback(() => {
-    setEditedMarkdown(rawMarkdown);
-    setIsEditingMarkdown(false);
-  }, [rawMarkdown]);
+  // Handle markdown text change
+  const handleMarkdownTextChange = useCallback((text: string) => {
+    setMarkdownText(text);
+    if (!isInitialLoad.current) {
+      markAsChanged();
+    }
+  }, [markAsChanged]);
 
   // Block types for the menu - Notion-style
   const blockTypes: {
@@ -833,11 +801,39 @@ export default function EditorScreen() {
                 )}
               </TouchableOpacity>
             )}
+            
+            {/* Тумблер Blocks ↔ Markdown */}
+            <View style={styles.modeToggleContainer}>
+              <TouchableOpacity
+                style={[
+                  styles.modeToggleButton,
+                  !isMarkdownMode && styles.modeToggleButtonActive,
+                ]}
+                onPress={() => {
+                  if (isMarkdownMode) {
+                    handleToggleMarkdownMode();
+                  }
+                }}
+              >
+                <Type size={14} color={!isMarkdownMode ? colors.background : colors.textSecondary} />
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.modeToggleButton,
+                  isMarkdownMode && styles.modeToggleButtonActive,
+                ]}
+                onPress={() => {
+                  if (!isMarkdownMode) {
+                    handleToggleMarkdownMode();
+                  }
+                }}
+              >
+                <Code size={14} color={isMarkdownMode ? colors.background : colors.textSecondary} />
+              </TouchableOpacity>
+            </View>
+
             <TouchableOpacity style={styles.actionButton} onPress={handleRename}>
               <Ionicons name="pencil" size={16} color={colors.textSecondary} />
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.actionButton} onPress={handleGetRawMarkdown}>
-              <Code size={16} color={colors.textSecondary} />
             </TouchableOpacity>
           </View>
         </View>
@@ -848,6 +844,31 @@ export default function EditorScreen() {
         <View style={[styles.editorContainer, styles.loadingContainer]}>
           <ActivityIndicator size="large" color={colors.text} />
           <Text style={[styles.loadingText, { color: colors.textSecondary }]}>Loading note...</Text>
+        </View>
+      ) : isMarkdownMode ? (
+        <View style={styles.editorContainer}>
+          <ScrollView 
+            style={styles.markdownScrollContainer}
+            contentContainerStyle={{ paddingBottom: keyboardOffset || 20 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <TextInput
+              style={[
+                styles.markdownEditor,
+                {
+                  backgroundColor: colors.background,
+                  color: colors.text,
+                },
+              ]}
+              value={markdownText}
+              onChangeText={handleMarkdownTextChange}
+              multiline
+              textAlignVertical="top"
+              placeholder="# Markdown text here..."
+              placeholderTextColor={colors.textSecondary}
+              autoFocus={false}
+            />
+          </ScrollView>
         </View>
       ) : (
         <View style={styles.editorContainer}>
@@ -920,109 +941,6 @@ export default function EditorScreen() {
         </View>
       </Modal>
 
-      {/* Raw Markdown Modal */}
-      <Modal
-        visible={showMarkdownModal}
-        transparent
-        animationType="fade"
-        onRequestClose={() => {
-          if (isEditingMarkdown) {
-            handleCancelEditMarkdown();
-          } else {
-            setShowMarkdownModal(false);
-          }
-        }}
-      >
-        <View style={styles.modalOverlay}>
-          <View style={[styles.modalContent, styles.markdownModalContent, { backgroundColor: colors.background }]}>
-            <View style={styles.markdownModalHeader}>
-              <Text style={[styles.modalTitle, { color: colors.text }]}>
-                {isEditingMarkdown ? 'Edit Markdown' : 'View Markdown'}
-              </Text>
-              <TouchableOpacity
-                onPress={() => {
-                  if (isEditingMarkdown) {
-                    handleCancelEditMarkdown();
-                  } else {
-                    setShowMarkdownModal(false);
-                  }
-                }}
-              >
-                <X size={24} color={colors.text} />
-              </TouchableOpacity>
-            </View>
-
-            {isEditingMarkdown ? (
-              <TextInput
-                style={[
-                  styles.markdownInput,
-                  {
-                    backgroundColor: colorScheme === 'dark' ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.02)',
-                    borderColor: colorScheme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)',
-                    color: colors.text,
-                  },
-                ]}
-                value={editedMarkdown}
-                onChangeText={setEditedMarkdown}
-                multiline
-                textAlignVertical="top"
-                placeholder="Enter your markdown here..."
-                placeholderTextColor={colors.textSecondary}
-                autoFocus
-              />
-            ) : (
-              <View
-                style={[
-                  styles.markdownContainer,
-                  {
-                    backgroundColor: colorScheme === 'dark' ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.02)',
-                    borderColor: colorScheme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)',
-                  },
-                ]}
-              >
-                <Text style={[styles.markdownText, { color: colors.text }]}>{rawMarkdown}</Text>
-              </View>
-            )}
-
-            <View style={styles.markdownModalActions}>
-              {isEditingMarkdown ? (
-                <>
-                  <TouchableOpacity
-                    style={[styles.modalButton, styles.modalButtonCancel]}
-                    onPress={handleCancelEditMarkdown}
-                  >
-                    <Text style={[styles.modalButtonTextCancel, { color: colors.text }]}>Cancel</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.modalButton, styles.modalButtonConfirm]}
-                    onPress={handleApplyMarkdown}
-                  >
-                    <Save size={16} color="#FFFFFF" />
-                    <Text style={styles.modalButtonTextConfirm}>Apply Changes</Text>
-                  </TouchableOpacity>
-                </>
-              ) : (
-                <>
-                  <TouchableOpacity
-                    style={[styles.modalButton, styles.modalButtonSecondary]}
-                    onPress={handleCopyFromModal}
-                  >
-                    <Copy size={16} color={colors.text} />
-                    <Text style={[styles.modalButtonTextSecondary, { color: colors.text }]}>Copy</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.modalButton, styles.modalButtonConfirm]}
-                    onPress={handleEditMarkdown}
-                  >
-                    <Ionicons name="pencil" size={16} color="#FFFFFF" />
-                    <Text style={styles.modalButtonTextConfirm}>Edit Markdown</Text>
-                  </TouchableOpacity>
-                </>
-              )}
-            </View>
-          </View>
-        </View>
-      </Modal>
     </SafeAreaView>
   );
 }
@@ -1234,9 +1152,37 @@ const getStyles = (colorScheme: 'light' | 'dark') => {
       justifyContent: 'center',
       backgroundColor: colors.surface,
     },
+    modeToggleContainer: {
+      flexDirection: 'row',
+      backgroundColor: colors.surface,
+      borderRadius: 14,
+      padding: 2,
+      gap: 2,
+    },
+    modeToggleButton: {
+      width: 28,
+      height: 28,
+      borderRadius: 12,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'transparent',
+    },
+    modeToggleButtonActive: {
+      backgroundColor: colors.tint,
+    },
     editorContainer: {
       flex: 1,
       backgroundColor: colors.background,
+    },
+    markdownScrollContainer: {
+      flex: 1,
+    },
+    markdownEditor: {
+      minHeight: '100%',
+      padding: 16,
+      fontSize: 16,
+      fontFamily: 'SpaceMono',
+      lineHeight: 24,
     },
     blockQuickContent: {
       paddingHorizontal: 12,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,14 +1,14 @@
 import { NoteCard } from '@/components/NoteCard';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import {
-    Animations,
-    BorderRadius,
-    Colors,
-    createTextStyle,
-    getThemeColors,
-    Shadows,
-    Spacing,
-    Typography,
+  Animations,
+  BorderRadius,
+  Colors,
+  createTextStyle,
+  getThemeColors,
+  Shadows,
+  Spacing,
+  Typography,
 } from '@/constants/DesignSystem';
 import { useStorage } from '@/contexts/StorageContext';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -16,15 +16,15 @@ import type { Note } from '@/types/storage';
 import { useRouter } from 'expo-router';
 import React, { useEffect, useRef, useState } from 'react';
 import {
-    Alert,
-    Animated,
-    FlatList,
-    StatusBar,
-    StyleSheet,
-    Text,
-    TextInput,
-    TouchableOpacity,
-    View,
+  Alert,
+  Animated,
+  FlatList,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -115,13 +115,13 @@ export default function HomeScreen() {
     if (!searchQuery) return true;
 
     const query = searchQuery.toLowerCase();
-    
+
     // Search in title
     if (note.title.toLowerCase().includes(query)) return true;
-    
+
     // Search in preview
     if (note.preview.toLowerCase().includes(query)) return true;
-    
+
     // Search in block content
     if (note.content && Array.isArray(note.content)) {
       const hasMatch = note.content.some((block: any) => {

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -125,24 +125,22 @@ export default function SettingsScreen() {
     if (!commitHash || commitHash === 'dev') return;
 
     const commitUrl = `https://github.com/StringNick/decanotes/commit/${commitHash}`;
-    
-    Alert.alert(
-      'View Commit',
-      `Open commit ${commitHash} on GitHub?`,
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Open',
-          onPress: () => {
-            import('expo-web-browser').then(({ openBrowserAsync }) => {
+
+    Alert.alert('View Commit', `Open commit ${commitHash} on GitHub?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Open',
+        onPress: () => {
+          import('expo-web-browser')
+            .then(({ openBrowserAsync }) => {
               openBrowserAsync(commitUrl);
-            }).catch(() => {
+            })
+            .catch(() => {
               Alert.alert('Commit Link', commitUrl);
             });
-          },
         },
-      ]
-    );
+      },
+    ]);
   };
 
   return (
@@ -166,16 +164,12 @@ export default function SettingsScreen() {
               subtitle={theme === 'system' ? 'Following system' : theme === 'dark' ? 'Dark' : 'Light'}
               colors={colors}
               onPress={() => {
-                Alert.alert(
-                  'Theme',
-                  'Choose your preferred theme',
-                  [
-                    { text: 'Light', onPress: () => setTheme('light') },
-                    { text: 'Dark', onPress: () => setTheme('dark') },
-                    { text: 'System', onPress: () => setTheme('system') },
-                    { text: 'Cancel', style: 'cancel' },
-                  ]
-                );
+                Alert.alert('Theme', 'Choose your preferred theme', [
+                  { text: 'Light', onPress: () => setTheme('light') },
+                  { text: 'Dark', onPress: () => setTheme('dark') },
+                  { text: 'System', onPress: () => setTheme('system') },
+                  { text: 'Cancel', style: 'cancel' },
+                ]);
               }}
             />
           </View>
@@ -192,10 +186,15 @@ export default function SettingsScreen() {
               onPress={() => {
                 Alert.alert(
                   'Auto-Save',
-                  autoSaveEnabled ? 'Disable auto-save? Changes will need to be saved manually.' : 'Enable auto-save? Changes will be saved automatically after 2 seconds.',
+                  autoSaveEnabled
+                    ? 'Disable auto-save? Changes will need to be saved manually.'
+                    : 'Enable auto-save? Changes will be saved automatically after 2 seconds.',
                   [
                     { text: 'Cancel', style: 'cancel' },
-                    { text: autoSaveEnabled ? 'Disable' : 'Enable', onPress: () => setAutoSaveEnabled(!autoSaveEnabled) },
+                    {
+                      text: autoSaveEnabled ? 'Disable' : 'Enable',
+                      onPress: () => setAutoSaveEnabled(!autoSaveEnabled),
+                    },
                   ]
                 );
               }}
@@ -255,11 +254,13 @@ export default function SettingsScreen() {
               onPress={() => {
                 // Open GitHub issues page
                 const githubIssuesUrl = 'https://github.com/StringNick/decanotes/issues';
-                import('expo-web-browser').then(({ openBrowserAsync }) => {
-                  openBrowserAsync(githubIssuesUrl);
-                }).catch(() => {
-                  Alert.alert('Help & Support', `Visit: ${githubIssuesUrl}`);
-                });
+                import('expo-web-browser')
+                  .then(({ openBrowserAsync }) => {
+                    openBrowserAsync(githubIssuesUrl);
+                  })
+                  .catch(() => {
+                    Alert.alert('Help & Support', `Visit: ${githubIssuesUrl}`);
+                  });
               }}
             />
             <SettingItem

--- a/components/editor/EditorKeyboard.ts
+++ b/components/editor/EditorKeyboard.ts
@@ -298,7 +298,7 @@ export function useEditorKeyboard(options: EditorKeyboardOptions) {
           handleTabKey(event);
           break;
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+       
     },
     [allShortcuts, pluginRegistry]
   );

--- a/components/editor/EditorKeyboard.ts
+++ b/components/editor/EditorKeyboard.ts
@@ -298,7 +298,6 @@ export function useEditorKeyboard(options: EditorKeyboardOptions) {
           handleTabKey(event);
           break;
       }
-       
     },
     [allShortcuts, pluginRegistry]
   );

--- a/components/editor/MarkdownEditor.tsx
+++ b/components/editor/MarkdownEditor.tsx
@@ -312,7 +312,6 @@ const EditorWithContext = forwardRef<ExtendedMarkdownEditorRef, ExtendedMarkdown
       getCurrentMode: () => {
         return 'edit' as any;
       },
-       
     }),
     [state, actions]
   );

--- a/components/editor/MarkdownEditor.tsx
+++ b/components/editor/MarkdownEditor.tsx
@@ -312,7 +312,7 @@ const EditorWithContext = forwardRef<ExtendedMarkdownEditorRef, ExtendedMarkdown
       getCurrentMode: () => {
         return 'edit' as any;
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+       
     }),
     [state, actions]
   );

--- a/components/editor/components/MarkdownSheet.tsx
+++ b/components/editor/components/MarkdownSheet.tsx
@@ -1,0 +1,369 @@
+import { Colors } from '@/constants/Colors';
+import { DesignSystem } from '@/constants/DesignSystem';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Ionicons } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
+import { Copy, Save, X } from 'lucide-react-native';
+import React, { useState } from 'react';
+import {
+    Alert,
+    Modal,
+    ScrollView,
+    StyleSheet,
+    Switch,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
+} from 'react-native';
+
+export type MarkdownSheetMode = 'view' | 'edit';
+
+interface MarkdownSheetProps {
+  visible: boolean;
+  markdown: string;
+  noteTitle: string;
+  noteId?: string;
+  onClose: () => void;
+  onApply?: (markdown: string) => void;
+  onCopy?: (markdown: string, includeLink: boolean) => void;
+}
+
+export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
+  visible,
+  markdown,
+  noteTitle,
+  noteId,
+  onClose,
+  onApply,
+  onCopy,
+}) => {
+  const { effectiveTheme } = useTheme();
+  const colorScheme = effectiveTheme;
+  const colors = Colors[colorScheme ?? 'light'];
+  
+  const [mode, setMode] = useState<MarkdownSheetMode>('view');
+  const [editedMarkdown, setEditedMarkdown] = useState(markdown);
+  const [includeLink, setIncludeLink] = useState(false);
+
+  // Reset state when sheet opens
+  React.useEffect(() => {
+    if (visible) {
+      setEditedMarkdown(markdown);
+      setMode('view');
+      setIncludeLink(false);
+    }
+  }, [visible, markdown]);
+
+  const handleCopy = async () => {
+    const contentToCopy = mode === 'edit' ? editedMarkdown : markdown;
+    
+    let finalContent = contentToCopy;
+    if (includeLink && noteId) {
+      const wikiLink = `[[${noteTitle}]]`;
+      const markdownLink = `[${noteTitle}](decanotes://note/${noteId})`;
+      finalContent = `${contentToCopy}\n\n---\n\nSource: ${includeLink ? wikiLink : markdownLink}`;
+    }
+
+    await Clipboard.setStringAsync(finalContent);
+    
+    if (onCopy) {
+      onCopy(finalContent, includeLink);
+    }
+    
+    Alert.alert('✓ Copied', 'Markdown copied to clipboard');
+    onClose();
+  };
+
+  const handleApply = () => {
+    if (onApply && editedMarkdown !== markdown) {
+      onApply(editedMarkdown);
+      Alert.alert('✓ Applied', 'Markdown changes applied');
+    }
+    onClose();
+  };
+
+  const styles = getStyles(colorScheme ?? 'light');
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <TouchableOpacity 
+          style={styles.backdrop} 
+          activeOpacity={1} 
+          onPress={onClose}
+        />
+        
+        <View style={[styles.sheet, { backgroundColor: colors.background }]}>
+          {/* Header with tabs */}
+          <View style={styles.header}>
+            <View style={styles.tabs}>
+              <TouchableOpacity
+                style={[styles.tab, mode === 'view' && styles.tabActive]}
+                onPress={() => setMode('view')}
+              >
+                <Ionicons 
+                  name="eye-outline" 
+                  size={18} 
+                  color={mode === 'view' ? colors.tint : colors.textSecondary} 
+                />
+                <Text style={[
+                  styles.tabText,
+                  { color: mode === 'view' ? colors.tint : colors.textSecondary }
+                ]}>
+                  Preview
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={[styles.tab, mode === 'edit' && styles.tabActive]}
+                onPress={() => setMode('edit')}
+              >
+                <Ionicons 
+                  name="create-outline" 
+                  size={18} 
+                  color={mode === 'edit' ? colors.tint : colors.textSecondary} 
+                />
+                <Text style={[
+                  styles.tabText,
+                  { color: mode === 'edit' ? colors.tint : colors.textSecondary }
+                ]}>
+                  Edit
+                </Text>
+              </TouchableOpacity>
+            </View>
+
+            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+              <X size={24} color={colors.text} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Content */}
+          <View style={styles.content}>
+            {mode === 'view' ? (
+              <ScrollView style={styles.scrollView}>
+                <View style={[
+                  styles.markdownContainer,
+                  {
+                    backgroundColor: colorScheme === 'dark' 
+                      ? DesignSystem.Colors.glass.dark.soft
+                      : DesignSystem.Colors.glass.light.soft,
+                    borderColor: colorScheme === 'dark' 
+                      ? 'rgba(255, 255, 255, 0.1)' 
+                      : 'rgba(0, 0, 0, 0.1)',
+                  }
+                ]}>
+                  <Text style={[styles.markdownText, { color: colors.text }]}>
+                    {markdown}
+                  </Text>
+                </View>
+              </ScrollView>
+            ) : (
+              <TextInput
+                style={[
+                  styles.markdownInput,
+                  {
+                    backgroundColor: colorScheme === 'dark' 
+                      ? DesignSystem.Colors.glass.dark.soft
+                      : DesignSystem.Colors.glass.light.soft,
+                    borderColor: colorScheme === 'dark' 
+                      ? 'rgba(255, 255, 255, 0.1)' 
+                      : 'rgba(0, 0, 0, 0.1)',
+                    color: colors.text,
+                  },
+                ]}
+                value={editedMarkdown}
+                onChangeText={setEditedMarkdown}
+                multiline
+                textAlignVertical="top"
+                placeholder="Enter your markdown here..."
+                placeholderTextColor={colors.textSecondary}
+                autoFocus
+              />
+            )}
+          </View>
+
+          {/* Footer with actions */}
+          <View style={[styles.footer, { borderTopColor: colors.border }]}>
+            <View style={styles.linkOption}>
+              <Text style={[styles.linkLabel, { color: colors.text }]}>
+                Add note link
+              </Text>
+              <Switch
+                value={includeLink}
+                onValueChange={setIncludeLink}
+                trackColor={{ 
+                  false: colors.surface, 
+                  true: colors.tint + '40' 
+                }}
+                thumbColor={includeLink ? colors.tint : colors.icon}
+              />
+            </View>
+
+            <View style={styles.actions}>
+              <TouchableOpacity
+                style={[styles.actionButton, styles.copyButton, { backgroundColor: colors.surface }]}
+                onPress={handleCopy}
+              >
+                <Copy size={16} color={colors.text} />
+                <Text style={[styles.actionText, { color: colors.text }]}>
+                  Copy & Close
+                </Text>
+              </TouchableOpacity>
+
+              {mode === 'edit' && onApply && editedMarkdown !== markdown && (
+                <TouchableOpacity
+                  style={[styles.actionButton, styles.applyButton, { backgroundColor: colors.tint }]}
+                  onPress={handleApply}
+                >
+                  <Save size={16} color="#FFFFFF" />
+                  <Text style={[styles.actionText, { color: '#FFFFFF' }]}>
+                    Apply
+                  </Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const getStyles = (colorScheme: 'light' | 'dark') => {
+  const colors = Colors[colorScheme];
+
+  return StyleSheet.create({
+    overlay: {
+      flex: 1,
+      justifyContent: 'flex-end',
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    backdrop: {
+      flex: 1,
+    },
+    sheet: {
+      borderTopLeftRadius: DesignSystem.BorderRadius['3xl'],
+      borderTopRightRadius: DesignSystem.BorderRadius['3xl'],
+      maxHeight: '75%',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: -4 },
+      shadowOpacity: 0.15,
+      shadowRadius: 12,
+      elevation: 12,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: DesignSystem.Spacing.lg,
+      paddingTop: DesignSystem.Spacing.lg,
+      paddingBottom: DesignSystem.Spacing.md,
+    },
+    tabs: {
+      flexDirection: 'row',
+      gap: DesignSystem.Spacing.sm,
+      backgroundColor: colorScheme === 'dark' 
+        ? 'rgba(255, 255, 255, 0.05)' 
+        : 'rgba(0, 0, 0, 0.03)',
+      borderRadius: DesignSystem.BorderRadius.lg,
+      padding: 4,
+    },
+    tab: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: DesignSystem.Spacing.xs,
+      paddingHorizontal: DesignSystem.Spacing.md,
+      paddingVertical: DesignSystem.Spacing.sm,
+      borderRadius: DesignSystem.BorderRadius.md,
+    },
+    tabActive: {
+      backgroundColor: colorScheme === 'dark' 
+        ? 'rgba(20, 184, 166, 0.15)' 
+        : 'rgba(20, 184, 166, 0.12)',
+    },
+    tabText: {
+      fontSize: DesignSystem.Typography.sizes.sm,
+      fontFamily: DesignSystem.Typography.fonts.medium,
+    },
+    closeButton: {
+      width: 36,
+      height: 36,
+      borderRadius: DesignSystem.BorderRadius.full,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: colors.surface,
+    },
+    content: {
+      flex: 1,
+      paddingHorizontal: DesignSystem.Spacing.lg,
+    },
+    scrollView: {
+      flex: 1,
+    },
+    markdownContainer: {
+      borderWidth: 1,
+      borderRadius: DesignSystem.BorderRadius.xl,
+      padding: DesignSystem.Spacing.base,
+      minHeight: 200,
+    },
+    markdownText: {
+      fontSize: DesignSystem.Typography.sizes.sm,
+      fontFamily: DesignSystem.Typography.fonts.mono,
+      lineHeight: 20,
+    },
+    markdownInput: {
+      borderWidth: 1,
+      borderRadius: DesignSystem.BorderRadius.xl,
+      padding: DesignSystem.Spacing.base,
+      minHeight: 300,
+      fontSize: DesignSystem.Typography.sizes.sm,
+      fontFamily: DesignSystem.Typography.fonts.mono,
+      lineHeight: 20,
+    },
+    footer: {
+      borderTopWidth: 1,
+      paddingHorizontal: DesignSystem.Spacing.lg,
+      paddingVertical: DesignSystem.Spacing.base,
+      gap: DesignSystem.Spacing.md,
+    },
+    linkOption: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    linkLabel: {
+      fontSize: DesignSystem.Typography.sizes.base,
+      fontFamily: DesignSystem.Typography.fonts.medium,
+    },
+    actions: {
+      flexDirection: 'row',
+      gap: DesignSystem.Spacing.md,
+    },
+    actionButton: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: DesignSystem.Spacing.xs,
+      paddingVertical: DesignSystem.Spacing.md,
+      paddingHorizontal: DesignSystem.Spacing.base,
+      borderRadius: DesignSystem.BorderRadius.lg,
+    },
+    copyButton: {
+      // Styles from surface background
+    },
+    applyButton: {
+      // Styles from tint background
+    },
+    actionText: {
+      fontSize: DesignSystem.Typography.sizes.base,
+      fontFamily: DesignSystem.Typography.fonts.medium,
+    },
+  });
+};

--- a/components/editor/components/MarkdownSheet.tsx
+++ b/components/editor/components/MarkdownSheet.tsx
@@ -5,17 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import { Copy, Save, X } from 'lucide-react-native';
 import React, { useState } from 'react';
-import {
-    Alert,
-    Modal,
-    ScrollView,
-    StyleSheet,
-    Switch,
-    Text,
-    TextInput,
-    TouchableOpacity,
-    View,
-} from 'react-native';
+import { Alert, Modal, ScrollView, StyleSheet, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 export type MarkdownSheetMode = 'view' | 'edit';
 
@@ -41,7 +31,7 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
   const { effectiveTheme } = useTheme();
   const colorScheme = effectiveTheme;
   const colors = Colors[colorScheme ?? 'light'];
-  
+
   const [mode, setMode] = useState<MarkdownSheetMode>('view');
   const [editedMarkdown, setEditedMarkdown] = useState(markdown);
   const [includeLink, setIncludeLink] = useState(false);
@@ -57,7 +47,7 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
 
   const handleCopy = async () => {
     const contentToCopy = mode === 'edit' ? editedMarkdown : markdown;
-    
+
     let finalContent = contentToCopy;
     if (includeLink && noteId) {
       const wikiLink = `[[${noteTitle}]]`;
@@ -66,11 +56,11 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
     }
 
     await Clipboard.setStringAsync(finalContent);
-    
+
     if (onCopy) {
       onCopy(finalContent, includeLink);
     }
-    
+
     Alert.alert('✓ Copied', 'Markdown copied to clipboard');
     onClose();
   };
@@ -86,19 +76,10 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
   const styles = getStyles(colorScheme ?? 'light');
 
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={onClose}
-    >
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
       <View style={styles.overlay}>
-        <TouchableOpacity 
-          style={styles.backdrop} 
-          activeOpacity={1} 
-          onPress={onClose}
-        />
-        
+        <TouchableOpacity style={styles.backdrop} activeOpacity={1} onPress={onClose} />
+
         <View style={[styles.sheet, { backgroundColor: colors.background }]}>
           {/* Header with tabs */}
           <View style={styles.header}>
@@ -107,15 +88,8 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
                 style={[styles.tab, mode === 'view' && styles.tabActive]}
                 onPress={() => setMode('view')}
               >
-                <Ionicons 
-                  name="eye-outline" 
-                  size={18} 
-                  color={mode === 'view' ? colors.tint : colors.textSecondary} 
-                />
-                <Text style={[
-                  styles.tabText,
-                  { color: mode === 'view' ? colors.tint : colors.textSecondary }
-                ]}>
+                <Ionicons name="eye-outline" size={18} color={mode === 'view' ? colors.tint : colors.textSecondary} />
+                <Text style={[styles.tabText, { color: mode === 'view' ? colors.tint : colors.textSecondary }]}>
                   Preview
                 </Text>
               </TouchableOpacity>
@@ -124,15 +98,12 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
                 style={[styles.tab, mode === 'edit' && styles.tabActive]}
                 onPress={() => setMode('edit')}
               >
-                <Ionicons 
-                  name="create-outline" 
-                  size={18} 
-                  color={mode === 'edit' ? colors.tint : colors.textSecondary} 
+                <Ionicons
+                  name="create-outline"
+                  size={18}
+                  color={mode === 'edit' ? colors.tint : colors.textSecondary}
                 />
-                <Text style={[
-                  styles.tabText,
-                  { color: mode === 'edit' ? colors.tint : colors.textSecondary }
-                ]}>
+                <Text style={[styles.tabText, { color: mode === 'edit' ? colors.tint : colors.textSecondary }]}>
                   Edit
                 </Text>
               </TouchableOpacity>
@@ -147,20 +118,19 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
           <View style={styles.content}>
             {mode === 'view' ? (
               <ScrollView style={styles.scrollView}>
-                <View style={[
-                  styles.markdownContainer,
-                  {
-                    backgroundColor: colorScheme === 'dark' 
-                      ? DesignSystem.Colors.glass.dark.soft
-                      : DesignSystem.Colors.glass.light.soft,
-                    borderColor: colorScheme === 'dark' 
-                      ? 'rgba(255, 255, 255, 0.1)' 
-                      : 'rgba(0, 0, 0, 0.1)',
-                  }
-                ]}>
-                  <Text style={[styles.markdownText, { color: colors.text }]}>
-                    {markdown}
-                  </Text>
+                <View
+                  style={[
+                    styles.markdownContainer,
+                    {
+                      backgroundColor:
+                        colorScheme === 'dark'
+                          ? DesignSystem.Colors.glass.dark.soft
+                          : DesignSystem.Colors.glass.light.soft,
+                      borderColor: colorScheme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)',
+                    },
+                  ]}
+                >
+                  <Text style={[styles.markdownText, { color: colors.text }]}>{markdown}</Text>
                 </View>
               </ScrollView>
             ) : (
@@ -168,12 +138,11 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
                 style={[
                   styles.markdownInput,
                   {
-                    backgroundColor: colorScheme === 'dark' 
-                      ? DesignSystem.Colors.glass.dark.soft
-                      : DesignSystem.Colors.glass.light.soft,
-                    borderColor: colorScheme === 'dark' 
-                      ? 'rgba(255, 255, 255, 0.1)' 
-                      : 'rgba(0, 0, 0, 0.1)',
+                    backgroundColor:
+                      colorScheme === 'dark'
+                        ? DesignSystem.Colors.glass.dark.soft
+                        : DesignSystem.Colors.glass.light.soft,
+                    borderColor: colorScheme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)',
                     color: colors.text,
                   },
                 ]}
@@ -191,15 +160,13 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
           {/* Footer with actions */}
           <View style={[styles.footer, { borderTopColor: colors.border }]}>
             <View style={styles.linkOption}>
-              <Text style={[styles.linkLabel, { color: colors.text }]}>
-                Add note link
-              </Text>
+              <Text style={[styles.linkLabel, { color: colors.text }]}>Add note link</Text>
               <Switch
                 value={includeLink}
                 onValueChange={setIncludeLink}
-                trackColor={{ 
-                  false: colors.surface, 
-                  true: colors.tint + '40' 
+                trackColor={{
+                  false: colors.surface,
+                  true: colors.tint + '40',
                 }}
                 thumbColor={includeLink ? colors.tint : colors.icon}
               />
@@ -211,9 +178,7 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
                 onPress={handleCopy}
               >
                 <Copy size={16} color={colors.text} />
-                <Text style={[styles.actionText, { color: colors.text }]}>
-                  Copy & Close
-                </Text>
+                <Text style={[styles.actionText, { color: colors.text }]}>Copy & Close</Text>
               </TouchableOpacity>
 
               {mode === 'edit' && onApply && editedMarkdown !== markdown && (
@@ -222,9 +187,7 @@ export const MarkdownSheet: React.FC<MarkdownSheetProps> = ({
                   onPress={handleApply}
                 >
                   <Save size={16} color="#FFFFFF" />
-                  <Text style={[styles.actionText, { color: '#FFFFFF' }]}>
-                    Apply
-                  </Text>
+                  <Text style={[styles.actionText, { color: '#FFFFFF' }]}>Apply</Text>
                 </TouchableOpacity>
               )}
             </View>
@@ -268,9 +231,7 @@ const getStyles = (colorScheme: 'light' | 'dark') => {
     tabs: {
       flexDirection: 'row',
       gap: DesignSystem.Spacing.sm,
-      backgroundColor: colorScheme === 'dark' 
-        ? 'rgba(255, 255, 255, 0.05)' 
-        : 'rgba(0, 0, 0, 0.03)',
+      backgroundColor: colorScheme === 'dark' ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.03)',
       borderRadius: DesignSystem.BorderRadius.lg,
       padding: 4,
     },
@@ -283,9 +244,7 @@ const getStyles = (colorScheme: 'light' | 'dark') => {
       borderRadius: DesignSystem.BorderRadius.md,
     },
     tabActive: {
-      backgroundColor: colorScheme === 'dark' 
-        ? 'rgba(20, 184, 166, 0.15)' 
-        : 'rgba(20, 184, 166, 0.12)',
+      backgroundColor: colorScheme === 'dark' ? 'rgba(20, 184, 166, 0.15)' : 'rgba(20, 184, 166, 0.12)',
     },
     tabText: {
       fontSize: DesignSystem.Typography.sizes.sm,

--- a/components/editor/core/EditorCore.tsx
+++ b/components/editor/core/EditorCore.tsx
@@ -1,27 +1,27 @@
 import { Ionicons } from '@expo/vector-icons';
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import {
-    Dimensions,
-    FlatList,
-    InteractionManager,
-    LayoutChangeEvent,
-    ListRenderItemInfo,
-    NativeScrollEvent,
-    NativeSyntheticEvent,
-    StyleSheet,
-    Text,
-    TouchableOpacity,
-    View,
+  Dimensions,
+  FlatList,
+  InteractionManager,
+  LayoutChangeEvent,
+  ListRenderItemInfo,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { EditorBlock, EditorBlockType } from '../../../types/editor';
 import { EditorBottomBar } from '../components/EditorBottomBar';
 import { PluginRegistry } from '../plugins/PluginRegistry';
 import {
-    EditorConfig,
-    EditorError,
-    ExtendedMarkdownEditorProps,
-    ExtendedMarkdownEditorRef,
+  EditorConfig,
+  EditorError,
+  ExtendedMarkdownEditorProps,
+  ExtendedMarkdownEditorRef,
 } from '../types/EditorTypes';
 import { BlockPlugin, MarkdownPlugin } from '../types/PluginTypes';
 import { FocusManager } from '../utils/FocusManager';

--- a/components/editor/types/EditorTypes.ts
+++ b/components/editor/types/EditorTypes.ts
@@ -46,6 +46,9 @@ export interface ExtendedMarkdownEditorProps {
   keyboardDockBlockSection?: React.ReactNode;
   keyboardDockFormattingSection?: React.ReactNode;
   keyboardDockActionSection?: React.ReactNode;
+
+  // Display mode for split-view support
+  displayMode?: 'blocks' | 'markdown' | 'split';
 }
 
 // Editor configuration

--- a/constants/DesignSystem.ts
+++ b/constants/DesignSystem.ts
@@ -130,6 +130,78 @@ export const Colors = {
       strong: 'rgba(24, 24, 27, 0.9)',
     },
   },
+
+  // Syntax highlighting tokens
+  syntax: {
+    light: {
+      code: {
+        background: 'rgba(244, 244, 245, 0.8)', // zinc-100 with transparency
+        border: 'rgba(228, 228, 231, 0.6)', // zinc-200 with transparency
+        text: '#18181B', // zinc-900
+      },
+      quote: {
+        background: 'rgba(167, 139, 250, 0.08)', // purple with low opacity
+        border: '#A78BFA', // purple-400
+        text: '#3F3F46', // zinc-700
+      },
+      callout: {
+        info: {
+          background: 'rgba(96, 165, 250, 0.12)', // blue-400
+          border: '#60A5FA',
+          text: '#1E3A5F',
+        },
+        warning: {
+          background: 'rgba(251, 191, 36, 0.12)', // amber-400
+          border: '#FBBF24',
+          text: '#78350F',
+        },
+        danger: {
+          background: 'rgba(248, 113, 113, 0.12)', // red-400
+          border: '#F87171',
+          text: '#7F1D1D',
+        },
+        success: {
+          background: 'rgba(52, 211, 153, 0.12)', // emerald-400
+          border: '#34D399',
+          text: '#064E3B',
+        },
+      },
+    },
+    dark: {
+      code: {
+        background: 'rgba(39, 39, 42, 0.8)', // zinc-800 with transparency
+        border: 'rgba(63, 63, 70, 0.6)', // zinc-700 with transparency
+        text: '#FAFAFA', // zinc-50
+      },
+      quote: {
+        background: 'rgba(167, 139, 250, 0.15)', // purple with medium opacity
+        border: '#A78BFA', // purple-400
+        text: '#E4E4E7', // zinc-200
+      },
+      callout: {
+        info: {
+          background: 'rgba(96, 165, 250, 0.18)', // blue-400
+          border: '#60A5FA',
+          text: '#DBEAFE',
+        },
+        warning: {
+          background: 'rgba(251, 191, 36, 0.18)', // amber-400
+          border: '#FBBF24',
+          text: '#FEF3C7',
+        },
+        danger: {
+          background: 'rgba(248, 113, 113, 0.18)', // red-400
+          border: '#F87171',
+          text: '#FECDD3',
+        },
+        success: {
+          background: 'rgba(52, 211, 153, 0.18)', // emerald-400
+          border: '#34D399',
+          text: '#D1FAE5',
+        },
+      },
+    },
+  },
 };
 
 // === TYPOGRAPHY ===


### PR DESCRIPTION
What’s added: A toggle between block editor and raw Markdown in EditorScreen, plus an inline Markdown TextInput. When switching back to blocks, content is parsed via parseMarkdownToBlocks and marked as changed if it differs.

New component: MarkdownSheet with preview/edit/copy modes, optional note-link insertion, and copy/apply actions.

Types: Extend editor props with displayMode: ‘blocks’ | ‘markdown’ | ‘split’.

Design system: New syntax highlighting and callout color tokens.

Cleanup: Remove unused imports, simplify markdown state handling, normalize formatting/whitespace across the project, and small readability/logging tweaks.